### PR TITLE
DRY radio dropdown

### DIFF
--- a/includes/js/bb-class-dropdown-frontend-script.js
+++ b/includes/js/bb-class-dropdown-frontend-script.js
@@ -7,6 +7,9 @@
 
 const BBClassDropdown = {
 
+	on  : '●',		// symbol for the singleton ON status
+	off : '○',		// symbol for the singleton OFF status
+
     addSingletonAttributes : function () {
 		// return early if there are no groups
 		if ( typeof BBClassOptions.options.groups !== 'object' ) return;
@@ -19,12 +22,43 @@ const BBClassDropdown = {
 			if ( typeof groupData.singleton == 'string' ) {
 				optGroupElement.setAttribute( 'singleton' , 1 );
 				optGroupElement.label = `${groupData.name}`;
-                		// prepend symbol to each option
-				optGroupElement.querySelectorAll('option').forEach(option => {
-					option.text = '○ ' + option.text; 
-				});
+                // prepend symbol to each option
+				/* add data-label to each option so we can juggle with the text */
 			}
 		}
+		// add data-label top all options so we can use it should we need it
+		classDropdown.querySelectorAll('option').forEach(option => {
+			option.dataset.label = option.text;
+		});
+		// add the singleton symbols to start this off
+		BBClassDropdown.updateSingletonOptions();
+	},
+
+	updateSingletonOptions : function() {
+		
+		// get current classes
+		const currentClasses = jQuery('.fl-builder-settings:visible input[name=class]').val().split(' ');
+		const classDropdown = parent.window.document.querySelector( '[data-target="class"]' );
+		// loop over the opgroup that are singleton and add 'label' prefix;
+		classDropdown.querySelectorAll( 'optgroup[singleton] option' ).forEach(el => {
+			// use the data-label with the on/off symbol to mark it as selected
+			el.text = 	(
+							currentClasses.includes(el.value) 
+								? BBClassDropdown.on 
+								: BBClassDropdown.off 
+						) + 
+						' ' + 
+						el.dataset.label; 
+		});
+
+		console.log('updating options');
+		// Update Select2 if enabled
+		if (classDropdown.classList.contains('select2-hidden-accessible')) {
+			// switch to jQuery to re-init the select2
+			jQuery(classDropdown).select2( 'destroy' );
+			jQuery(classDropdown).select2();
+		}
+		
 	},
 
     handleDropdownSelection: function () {
@@ -51,17 +85,8 @@ const BBClassDropdown = {
 		if (optGroup && optGroup.getAttribute('singleton') !== '1') {
 			// Original behavior for non-singleton optgroups
 			newValue = ( currentValue.trim() + ' ' + addingValue.trim() ).trim();
-			textField.val( newValue ).trigger( 'change' ).trigger( 'keyup' );
+			//textField.val( newValue ).trigger( 'change' ).trigger( 'keyup' );
 
-			// Update Select2 if enabled
-			if (dropdown.hasClass('select2-hidden-accessible')) {
-				dropdown.select2('destroy').select2();
-				dropdown.val(''); // Resetting the selector
-			} else {
-				dropdown.val('');
-			}
-			return;
-			
 		}
 
 		let classes = [];
@@ -101,10 +126,6 @@ const BBClassDropdown = {
 				.trigger( 'change' )
 				.trigger( 'keyup' );
 
-			// Change symbol for all options in optgroup
-			optGroupOptions.forEach(option => option.text = '○ ' + option.text.split(' ')[1]);
-			// Change symbol for selected option
-			selectedOption.text = '● ' + selectedOption.text.split(' ')[1];
 		} else {
 			// Adding selected value to target text field only once
             
@@ -121,79 +142,54 @@ const BBClassDropdown = {
 					.trigger( 'change' )
 					.trigger( 'keyup' );
 
-				// Change symbol for selected option
-				if (selectedOption) {
-					selectedOption.text = '● ' + selectedOption.text.split(' ')[1];
-				}
 			}
 		}
-
-		// Update Select2 if enabled
-		if (dropdown.hasClass('select2-hidden-accessible')) {
-			dropdown.select2('destroy').select2();
-			dropdown.val(''); // Resetting the selector
-		} else {
-			dropdown.val('');
-		}
+		
+		dropdown.val(''); // Resetting the selector
+		console.log( 'method handleDropdownSelection ran' );
 	},
-
+	
 };
 
 jQuery(document).ready(function($) {
+
+	let timeout = null;
 
     FLBuilder.addHook('settings-form-init', BBClassDropdown.addSingletonAttributes );
     
     // Function to disable already used classes in the dropdown
     function disableUsedClasses() {
-		console.log('disableUsedClasses ran')
-        // get the current classes in the input field
+		console.log('method disableUsedClasses started')
+
+		// get the current classes in the input field
         var currentClasses = $('.fl-builder-settings:visible input[name=class]').val().split(' ');
 
         // reset all the disabled attributes
         $('.fl-text-field-add-value option').prop('disabled', false);
-
-        // loop through each class in the input field
-        $.each(currentClasses, function(index, classInField) {
-            // find the option with that value and set its disabled attribute to true
-            $('.fl-text-field-add-value option[value="' + classInField + '"]').prop('disabled', true);
-			console.log('disabled existing classes')
-        });
 		
-		// This kinda fixes the problem, but not entirely - it only adds the ● after you click in the <select> a first time
-        	// Based on my tests, my guess is the singleton attr isn't added yet when it loads the first time
-		$('optgroup[singleton="1"]').each(function() {
-			console.log('loop over singleton optgroups')
-			// Iterate over each option within the optgroup
-			$(this).find('option').each(function() {
-				// Get the value of the option
-				var optionValue = $(this).val();
-
-				// Check if the option value is in the currentClasses array
-				if (currentClasses.includes(optionValue)) {
-					console.log('replace symbol')
-					// Replace the first character of the option text with ●
-					var optionText = $(this).text();
-					optionText = '●' + optionText.substring(1);
-					$(this).text(optionText);
-				}
-			});
-		});
+        // loop through each class in the input field
+        $.each(currentClasses, function(index, classname) {
+			// find the option with that value and set its disabled attribute to true
+            $('.fl-text-field-add-value option[value="' + classname + '"]').prop('disabled', true);
+        });
+		console.log('disabled existing classes')
+		
+		// now update the singleton options
+		BBClassDropdown.updateSingletonOptions();
+		console.log('method disableUsedClasses ran')
     }
 
-    // listen for changes on the class input field
-    $('body', window.parent.document).on( 'change keyup', '.fl-builder-settings:visible input[name=class]', function() {
-        disableUsedClasses();
-    });
-    
-    // Listen for changes on the class select field
-    $('body', window.parent.document).on( 'change', '.fl-builder-settings:visible .fl-text-field-add-value', function() {
-        disableUsedClasses();
-    });
+	// remove the default FLBuilder event handler that clears the value after it's done
+	$('body', window.parent.document).off( 'change', '.fl-text-field-add-value', FLBuilder._textFieldAddValueSelectChange);
+	
+	// add our own callback to the dropdown
+	$('body', window.parent.document).on( 'change', '.fl-text-field-add-value', BBClassDropdown.handleDropdownSelection );
 
-    // remove the default FLBuilder event handler that clears the value after it's done
-    $('body', window.parent.document).off( 'change', '.fl-text-field-add-value', FLBuilder._textFieldAddValueSelectChange);
-
-    // add our own callback
-    $( 'body', window.parent.document).on( 'change', '.fl-text-field-add-value', BBClassDropdown.handleDropdownSelection );
-
+	// listen for changes on the text-input class field
+	$('body', window.parent.document).on( 'change keyup', '.fl-builder-settings:visible input[name=class]', function() {
+		// use debounce to prevent too many changes when using the keyboard
+		clearTimeout( timeout );
+		timeout = setTimeout( function() {disableUsedClasses();} , 250 );
+	});
+	
 });

--- a/includes/js/bb-class-dropdown-frontend-script.js
+++ b/includes/js/bb-class-dropdown-frontend-script.js
@@ -191,5 +191,10 @@ jQuery(document).ready(function($) {
 		clearTimeout( timeout );
 		timeout = setTimeout( function() {disableUsedClasses();} , 250 );
 	});
+
+	// listen for changes on the class select field
+	$('body', window.parent.document).on( 'change', '.fl-builder-settings:visible .fl-text-field-add-value', function() {
+	    disableUsedClasses();
+	});
 	
 });


### PR DESCRIPTION
Lots of changes here. Made the code more DRY (Don't Repeat Yourself).

After adding more console.logs I noticed some events kept triggering because of changes to the other element. Removed one event from the list, all seems to work.

select2 seems to not like it though. For me, at some point it seems to become sluggish. I have less of that when I keep select2 disabled.